### PR TITLE
[IO-1584][external] Add ARM64 to wheels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest, ARM64]
         python-version: [3.6, 3.7, 3.8, 3.9, '3.10', '3.11']
 
     steps:


### PR DESCRIPTION
We currently don't have ARM64 wheels for Mac M1 and Pine/Rockwell hardware, various others.  This adds wheels for these.