### PR TITLE
[PLA-1636] upgrade artifacts action version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
           output-dir: dist
           config-file: "{package}/pyproject.toml"
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: ${{ env.RELEASE_VERSION != ''}}
         with:
           name: ${{ env.RELEASE_VERSION }}-wheels
@@ -56,7 +56,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install setuptools wheel twine
           python setup.py sdist
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: ${{ env.RELEASE_VERSION != ''}}
         with:
           name: ${{ env.RELEASE_VERSION }}-sdist

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Retrieve wheel artifacts for release
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@v6
         with:
           name: ${{ github.event.release.name }}-wheels
           repo: ${{ github.repository }}
@@ -36,7 +36,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Retrieve SDIST artifacts for release
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@v6
         with:
           name: ${{ github.event.release.name }}-sdist
           repo: ${{ github.repository }}


### PR DESCRIPTION
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
> Starting November 30, 2024, GitHub Actions customers will no longer be able to use v3 of [actions/upload-artifact](https://github.com/actions/upload-artifact) or [actions/download-artifact](https://github.com/actions/download-artifact). Customers should update workflows to begin using [v4 of the artifact actions](https://github.blog/2024-02-12-get-started-with-v4-of-github-actions-artifacts/) as soon as possible.