### PR TITLE
[DAR-7748] fix: use bash shell for env var in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set env
+        shell: bash
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
       - name: Build wheels

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,8 +29,7 @@ jobs:
           name_is_regexp: true
           repo: ${{ github.repository }}
           workflow: build.yml
-          path: ./dist
-          merge_multiple: true
+          path: ./dist-raw
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Retrieve SDIST artifacts for release
@@ -39,10 +38,15 @@ jobs:
           name: ${{ github.event.release.name }}-sdist
           repo: ${{ github.repository }}
           workflow: build.yml
-          path: ./dist
+          path: ./dist-raw
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-      # Test step for debugging
+      - name: Flatten artifacts into dist
+        run: |
+          mkdir -p ./dist
+          find ./dist-raw -name '*.whl' -exec mv {} ./dist/ \;
+          find ./dist-raw -name '*.tar.gz' -exec mv {} ./dist/ \;
+
       - name: Display structure of downloaded files
         run: ls -laR
         working-directory: ./dist


### PR DESCRIPTION
## Summary
DAR-7748
Fixes two CI issues discovered during the v0.2.0 release:

1. **build.yml**: The `Set env` step uses bash parameter expansion (`${GITHUB_REF#refs/*/}`) which doesn't work in PowerShell (Windows default shell). Adding `shell: bash` ensures the step works on all platforms. This caused Windows wheel artifacts to not be uploaded.

2. **deploy.yml**: The `dawidd6/action-download-artifact@v6` downloads each matching artifact into its own subdirectory. The `pypa/gh-action-pypi-publish` action then fails because it encounters directories instead of `.whl`/`.tar.gz` files. Fixed by downloading to `dist-raw/` and flattening into `dist/`. Also removed unsupported `merge_multiple` parameter.

## Test plan

- [ ] After merge: delete v0.2.0 tag+release, re-tag, re-release
- [ ] Verify Windows wheel artifacts are uploaded
- [ ] Verify deploy workflow publishes to PyPI successfully